### PR TITLE
Problem: maintainers should perform architectural and strategic review

### DIFF
--- a/1/README.md
+++ b/1/README.md
@@ -75,6 +75,7 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 1. To accept or reject a patch, a Maintainer SHALL use the Platform interface.
 1. Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
 1. Maintainers SHOULD review patches for consistency with architectural decisions and project goals
+1. If there is an issue with the patch preventing acceptance, maintainers SHOULD provide rapid and helpful feedback to enable contributors to amend their patch.
 1. Assuming consistency with above, maintainers SHALL merge correct patches from other Contributors rapidly.
 1. Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
 1. The user who created an issue SHOULD close the issue after checking the patch is successful.

--- a/1/README.md
+++ b/1/README.md
@@ -74,11 +74,11 @@ C4 is meant to provide a reusable optimal collaboration model for open source so
 1. To discuss a patch, people MAY comment on the Platform pull request, on the commit, or elsewhere.
 1. To accept or reject a patch, a Maintainer SHALL use the Platform interface.
 1. Maintainers SHOULD NOT merge their own patches except in exceptional cases, such as non-responsiveness from other Maintainers for an extended period (more than 1-2 days).
-1. Maintainers SHALL NOT make value judgments on correct patches.
-1. Maintainers SHALL merge correct patches from other Contributors rapidly.
+1. Maintainers SHOULD review patches for consistency with architectural decisions and project goals
+1. Assuming consistency with above, maintainers SHALL merge correct patches from other Contributors rapidly.
 1. Maintainers MAY merge incorrect patches from other Contributors with the goals of (a) ending fruitless discussions, (b) capturing toxic patches in the historical record, (c) engaging with the Contributor on improving their patch quality.
 1. The user who created an issue SHOULD close the issue after checking the patch is successful.
-1. Any Contributor who has value judgments on a patch SHOULD express these via their own patches.
+1. Any Contributor who has value judgements on a patch SHOULD express these via their own patches.
 1. Maintainers SHOULD close user issues that are left open without action for an uncomfortable period of time.
 
 ### 2.5. Branches and Releases


### PR DESCRIPTION
In the previous version, Maintainers were expected to merge "correct patches" without consideration for strategic project goals and architectural impact. This risks wasting contributors' time with patches that cause divergence from these areas.

This PR improves this process by adding an expectation that maintainers will review patches for consistency with architecture and projects goals. Patches that do not have major impacts in these areas should be merged rapidly as before.

This is consistent with other major open source projects, where maintainers (or a BDFL) perform such reviews and give feedback where necessary.