### PR TITLE
OEP-08: new link structure

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -153,7 +153,7 @@ Here is a representation of an example Asset using the schema described:
     "curation": {
         "rating": 0.93,
         "numVotes": 123,
-        "schema": "Binary Votting"
+        "schema": "Binary Voting"
     },
     "additionalInformation" : {
         "updateFrecuency": "yearly",

--- a/8/README.md
+++ b/8/README.md
@@ -135,20 +135,19 @@ Here is a representation of an example Asset using the schema described:
         "contentUrls": ["https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip"],
         "links": [
             {
-                "name" : "Sample of Asset Data",
-                "type" : "sample",
+                "name": "Sample of Asset Data",
+                "type": "sample",
                 "url": "https://foo.com/sample.csv"
             },
             {
-                "name" : "Data Format Definition",
-                "type" : "format",
+                "name": "Data Format Definition",
+                "type": "format",
                 "AssetID": "4d517500da0acb0d65a716f61330969334630363ce4a6a9d39691026ac7908ea"
             }
         ],
         "inLanguage": "en",
         "tags": "weather, uk, 2011, temperature, humidity",
         "price": 10
-
     },
     "curation": {
         "rating": 0.93,
@@ -157,8 +156,16 @@ Here is a representation of an example Asset using the schema described:
     },
     "additionalInformation" : {
         "updateFrecuency": "yearly",
-        "structuredMarkup" : [ { "uri" : "http://skos.um.es/unescothes/C01194/jsonld", "mediaType" : "application/ld+json"},
-                               { "uri" : "http://skos.um.es/unescothes/C01194/turtle", "mediaType" : "text/turtle"}]
+        "structuredMarkup": [
+            {
+                "uri": "http://skos.um.es/unescothes/C01194/jsonld",
+                "mediaType": "application/ld+json"
+            },
+            {
+                "uri": "http://skos.um.es/unescothes/C01194/turtle",
+                "mediaType": "text/turtle"
+            }
+        ]
     }
 }
 ```

--- a/8/README.md
+++ b/8/README.md
@@ -4,7 +4,7 @@ name: Assets Metadata Ontology
 type: Standard
 status: Raw
 editor: Aitor Argomaniz <aitor@oceanprotocol.com>
-contributors:
+contributors: Kiran Karkera <kiran.karkera@dex.sg>, Enrique Ruiz <enrique@oceanprotocol.com>, Mike Anderson <mike.anderson@dex.sg>, Matthias Kretschmann <matthias@oceanprotocol.com>
 ```
 
 
@@ -75,7 +75,7 @@ Attribute       |   Type        |   Required    | Description
 **contentType** | Text          | Yes           | File format if applicable
 **workExample** | Text          | No            | Example of the concept of this asset. This example is part of the metadata, not an external link.
 **contentUrls** | Text          | Yes           | List of content urls resolving the ASSET files
-**links**       | Text       | No               | Mapping of links for data samples, or links to find out more information. The key represents the topic of the link, the value is the proper link
+**links**       | Array of Link | No            | Mapping of links for data samples, or links to find out more information. Links may be to either a URL or another Asset. We expect tribes and/or marketplaces to converge on agreements of typical formats for linked data: The Ocean protocol itself does not mandate any specific formats as requirements are likely to be domain-specific.
 **inLanguage**  | Text          | No            | The language of the content or performance or used in an action. Please use one of the language codes from the [IETF BCP 47 standard](https://tools.ietf.org/html/bcp47)
 **tags**        | Text          | No            | Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas. Empty by default
 **price**       | Number        | Yes           | Price of the asset. If not specified would be 0.
@@ -90,7 +90,6 @@ Attribute       |   Type        |   Required    | Description
 **rating**     | Number (decimal)       | Yes              | Decimal values between 0 and 1. 0 is the default value
 **numVotes**    | Integer       | Yes              | Number of votes. 0 is the default value
 **schema**      | Text          | No              | Schema applied to calculate the rating
-
 
 
 ## Additional Information
@@ -115,7 +114,7 @@ Additional attributes are totally free to add and can be defined by the publishe
 
 ## Example
 
-Here a representation of an example Asset using the schema described:
+Here is a representation of an example Asset using the schema described:
 
 ```json
 {
@@ -135,17 +134,24 @@ Here a representation of an example Asset using the schema described:
                         423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68",
         "contentUrls": ["https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip"],
         "links": [
-            {"sample1": "http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-daily/"},
-            {"sample2": "http://data.ceda.ac.uk/badc/ukcp09/data/gridded-land-obs/gridded-land-obs-averages-25km/"},
-            {"fieldsDescription": "http://data.ceda.ac.uk/badc/ukcp09/"}
-         ],
+            {
+                "name" : "Sample of Asset Data",
+                "type" : "sample",
+                "url": "https://foo.com/sample.csv"
+            },
+            {
+                "name" : "Data Format Definition",
+                "type" : "format",
+                "AssetID": "4d517500da0acb0d65a716f61330969334630363ce4a6a9d39691026ac7908ea"
+            }
+        ],
         "inLanguage": "en",
         "tags": "weather, uk, 2011, temperature, humidity",
         "price": 10
 
     },
     "curation": {
-        "rating": 0.93
+        "rating": 0.93,
         "numVotes": 123,
         "schema": "Binary Votting"
     },
@@ -158,8 +164,6 @@ Here a representation of an example Asset using the schema described:
 ```
 
 
-
-
 ## References
 
 [Schema.org](https://schema.org/) is a collaborative, community activity with a mission to create, maintain, and promote schemas for structured data on the Internet,
@@ -170,9 +174,4 @@ Schemas:
 * DataSet - https://schema.org/Dataset
 * FileSize - https://schema.org/fileSize
 * Common license types for datasets - https://help.data.world/hc/en-us/articles/115006114287-Common-license-types-for-datasets
-
-
-
-
-
 


### PR DESCRIPTION
Minimal change to adapt the `links` structure suggested in #82 since that PR seems to require more discussion. 

* added all information about `links` it to the attributes table, and links example is just part of full Asset metadata example
* added contributors

New links structure has already been adapted in _Pleuston_ in https://github.com/oceanprotocol/pleuston/pull/151