### PR TITLE
Replace 'tribes' with 'domains'

### DIFF
--- a/11/README.md
+++ b/11/README.md
@@ -77,7 +77,7 @@ The different actors interacting in this flow are:
 
 * PUBLISHERS - Provide access to Assets and/or Services
 * CONSUMERS - Want to get access to Assets or Services
-* MARKETPLACES or TRIBES - Store the DDO/Metadata related with the Assets
+* MARKETPLACES or DOMAINS - Store the DDO/Metadata related with the Assets
 
 ### Technical components
 

--- a/7/README.md
+++ b/7/README.md
@@ -59,7 +59,7 @@ The main motivations of this OEP are:
 * Design a solution facilitating alignment of on-chain and off-chain information
 * Establishing the mechanism to know if the DDO associated with a DID was modified
 * Defining the common mechanisms, interfaces and APIs to implemented the designed solution
-* Define how Ocean assets, agents and tribes can be modeled with a DID/DDO data model
+* Define how Ocean assets, agents and domains can be modeled with a DID/DDO data model
 * Understand how DID hubs are formed, and how they integrate a business and storage layer
 
 ## Specification

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In the future, we can add more people to this list.
 
 Some people have specializations:
 
-- Tribes: @diminator
+- Domains: @diminator
 - Research: @diminator, @trentmc
 - Ocean Core [Tethys](https://github.com/oceanprotocol/ocean/projects/2): @aaitor
 


### PR DESCRIPTION
There were four instances of 'tribes' in the master branch. This pull request only changes three of them, because pull request #100 (not merged yet) already removed 'tribes' from OEP 8.