### PR TITLE
Remove to-be-merged from master view

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,12 @@ Short Name    | Title                                                        | T
 [2/COSS](2)   | Consensus-Oriented Specification System                      | Meta     | Draft      | Dimitri De Jonghe
 [3/ARCH](3)   | Ocean Core Architecture                                      | Standard | Draft      | Dimitri De Jonghe
 [4/AGENT](4)  | Ocean Agent Protocol Stack                                   | Standard | Draft      | Aitor Argomaniz
-[6/INVOKE](4)  | Invokable Compute Services                                  | Standard | To be merged      | Kiran Karkera
 [7/DID](7)    | Decentralized Identifiers									 | Standard | Draft      | Aitor Argomaniz
 [8/ASSET-DDO](8)| Assets Metadata Ontology                                   | Standard | Raw      | Aitor Argomaniz
 [9/BOUNTY](9)  | Bounties in Ocean Protocol                       	 		 | Standard | Raw      | Chalid Mannaa, Manan Patel
 [10/OAA](10)  | On-Chain Access Control                       				 | Standard | Draft      | Ahmed Ali
 [11/ACL](11)    | On-Chain Access Control using Service Agreements           | Standard | Raw      | Aitor Argomaniz
-[12/PROV](12)| Provenance                              				         | Standard | To be merged         | Kiran Karkera
-[13/META](13)| Off-chain Asset Metadata                                      | Standard | To be merged         | Mike Anderson
-[15/META-API](15)| API for metadata access                                   | Standard | To be merged         | Mike Anderson
-[16/MARKET-API](16)| API for Ocean Marketplaces                              | Standard | To be merged         | Mike Anderson
-[17/STORAGE-API](17)| API for Off-chain storage                              | Standard | To be merged         | Mike Anderson
-[18/TRUST-API](18)| API for trust verification                              | Standard | To be merged         | Mike Anderson
-[19/ENDPOINTS](19)| Ocean Agent Endpoints                                    | Standard | To be merged         | Mike Anderson
- 
+
 
 # Current Participants
 


### PR DESCRIPTION
The to-be-merged OEPs cause confusion, as there is no clarity if they require to be an OEP at the protocol level (ie level 1) or rather as API definitions in layer 2 or layer 3