### PR TITLE
Adding files entry with more required information about the contents and removing contentUrls

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -70,11 +70,11 @@ Attribute       |   Type        |   Required    | Description
 **compression** | Text          | No            | File compression (e.g. no, gzip, bzip2, etc).
 **contentType** | Text          | Yes           | File format, if applicable.
 **workExample** | Text          | No            | Example of the concept of this asset. This example is part of the metadata, not an external link.
-**contentUrls** | Text          | Yes           | List of content URLs resolving the Asset files.
 **links**       | Array of Link | No            | Mapping of links for data samples, or links to find out more information. Links may be to either a URL or another Asset. We expect marketplaces to converge on agreements of typical formats for linked data: The Ocean Protocol itself does not mandate any specific formats as these requirements are likely to be domain-specific.
 **inLanguage**  | Text          | No            | The language of the content. Please use one of the language codes from the [IETF BCP 47 standard](https://tools.ietf.org/html/bcp47).
 **tags**        | Text          | No            | Keywords or tags used to describe this content. Multiple entries in a keyword list are typically delimited by commas. Empty by default.
 **price**       | Number        | Yes           | Price of the asset. If not specified, then the default is 0.
+**files**       | Array of Files| Yes           | Array of File objects including the encrypted file urls, checksum (optional), content lenght in bytes (optional) and remote resourceId (optional)
 
 ## Curation Attributes
 
@@ -104,6 +104,20 @@ These are examples of attributes that can enhance the discoverability of a resou
 
 The publisher of a DDO MAY add additional attributes (i.e. in addition to those listed above).
 
+## Files
+
+The `files` attribute includes the details necessary to consume and validate de data.
+This attribute include an array of objects of type `file`. The type file has the following attributes:
+
+| Attribute             | Description                                                                                                                  |
+| -                     | -                                                                                                                            |
+| **url**               | Content Url (mandatory). The URL is encrypted.                                                                               |
+| **checksum**          | Checksum of the file using MD5 (optional). If it's not provided can't be validated if the file was not modified after registering. |
+| **contentLenght**     | Size of the file in bytes (optional).                                                                                        |
+| **resourceId**        | Remote identifier of the file in the external provider (optional). It is tipically the remote id in the cloud provider. |
+
+Only the **url** attribute is mandatory.
+
 ## Example
 
 Here is an example of an Asset Metadata object following the above-described schema:
@@ -124,7 +138,22 @@ Here is an example of an Asset Metadata object following the above-described sch
         "contentType": "text/csv",
         "workExample": "stationId,latitude,longitude,datetime,temperature,humidity\n
                         423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68",
-        "contentUrls": ["https://testocnfiles.blob.core.windows.net/testfiles/testzkp.zip"],
+        "files": [
+            {
+                "url": "234ab87234acbd09543085340abffh21983ddhiiee982143827423421",
+                "checksum": "efb2c764274b745f5fc37f97c6b0e761",
+                "contentLenght": "4535431",
+                "resourceId": "access-log2018-02-13-15-17-29-18386C502CAEA932"
+            },
+            {
+                "url": "234ab87234acbd6894237582309543085340abffh21983ddhiiee982143827423421",
+                "checksum": "085340abffh21495345af97c6b0e761",
+                "contentLenght": "12324"
+            },
+            {
+                "url": "80684089027358963495379879a543085340abffh21983ddhiiee982143827abcc2",
+            }
+        ],
         "links": [
             {
                 "name": "Sample of Asset Data",

--- a/8/README.md
+++ b/8/README.md
@@ -74,7 +74,7 @@ Attribute       |   Type        |   Required    | Description
 **inLanguage**  | Text          | No            | The language of the content. Please use one of the language codes from the [IETF BCP 47 standard](https://tools.ietf.org/html/bcp47).
 **tags**        | Text          | No            | Keywords or tags used to describe this content. Multiple entries in a keyword list are typically delimited by commas. Empty by default.
 **price**       | Number        | Yes           | Price of the asset. If not specified, then the default is 0.
-**files**       | Array of Files| Yes           | Array of File objects including the encrypted file urls, checksum (optional), content lenght in bytes (optional) and remote resourceId (optional)
+**files**       | Array of Files| Yes           | Array of File objects including the encrypted file urls, checksum (optional), content length in bytes (optional) and remote resourceId (optional)
 
 ## Curation Attributes
 
@@ -106,15 +106,15 @@ The publisher of a DDO MAY add additional attributes (i.e. in addition to those 
 
 ## Files
 
-The `files` attribute includes the details necessary to consume and validate de data.
+The `files` attribute includes the details necessary to consume and validate the data.
 This attribute include an array of objects of type `file`. The type file has the following attributes:
 
 | Attribute             | Description                                                                                                                  |
 | -                     | -                                                                                                                            |
 | **url**               | Content Url (mandatory). The URL is encrypted.                                                                               |
 | **checksum**          | Checksum of the file using MD5 (optional). If it's not provided can't be validated if the file was not modified after registering. |
-| **contentLenght**     | Size of the file in bytes (optional).                                                                                        |
-| **resourceId**        | Remote identifier of the file in the external provider (optional). It is tipically the remote id in the cloud provider. |
+| **contentLength**     | Size of the file in bytes (optional).                                                                                        |
+| **resourceId**        | Remote identifier of the file in the external provider (optional). It is typically the remote id in the cloud provider. |
 
 Only the **url** attribute is mandatory.
 
@@ -142,13 +142,13 @@ Here is an example of an Asset Metadata object following the above-described sch
             {
                 "url": "234ab87234acbd09543085340abffh21983ddhiiee982143827423421",
                 "checksum": "efb2c764274b745f5fc37f97c6b0e761",
-                "contentLenght": "4535431",
+                "contentLength": "4535431",
                 "resourceId": "access-log2018-02-13-15-17-29-18386C502CAEA932"
             },
             {
                 "url": "234ab87234acbd6894237582309543085340abffh21983ddhiiee982143827423421",
                 "checksum": "085340abffh21495345af97c6b0e761",
-                "contentLenght": "12324"
+                "contentLength": "12324"
             },
             {
                 "url": "80684089027358963495379879a543085340abffh21983ddhiiee982143827abcc2",


### PR DESCRIPTION
The idea of this PR is to improve the old `contentUrls` attribute to having the `files` entry. It should provide some more required attributes (checksum, content length, etc.) This information will be necessary for validation purposes.

This is a breaking change.