### PR TITLE
Feature/oep8 validate aquarius

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -71,7 +71,8 @@ Attribute       |   Type        |   Required    | Description
 **license**     | Text          | Yes           | Short name referencing the license of the asset (e.g. Public Domain, CC-0, CC-BY, No License Specified, etc. ). If it's not specified, the following value will be added: "No License Specified".
 **contentType** | Text          | Yes           | File format, if applicable.
 **price**       | Number        | Yes           | Price of the asset. If not specified, then the default is 0.
-**files**       | Array of Files| Yes           | Array of File objects including the encrypted file urls, checksum (optional), content length in bytes (optional) and remote resourceId (optional)
+**files**       | Array of Files| No            | Array of File objects including the encrypted file urls, checksum (optional), content length in bytes (optional) and remote resourceId (optional)
+**encryptedFiles | Text         | No            | Encrypted string of the files **attribute**. 
 **checksum**    | Text          | Yes           | SHA3 Hash of concatenated values : [list of all file checksums] + name + author + license + did
 **categories**  | Array of Text | No            | Optional array of categories associated to the Asset.
 **tags**        | Array of Text | No            | Keywords or tags used to describe this content. Multiple entries in a keyword list are typically delimited by commas. Empty by default.

--- a/8/README.md
+++ b/8/README.md
@@ -72,7 +72,7 @@ Attribute       |   Type        |   Required    | Description
 **contentType** | Text          | Yes           | File format, if applicable.
 **price**       | Number        | Yes           | Price of the asset. If not specified, then the default is 0.
 **files**       | Array of Files| No            | Array of File objects including the encrypted file urls, checksum (optional), content length in bytes (optional) and remote resourceId (optional)
-**encryptedFiles | Text         | No            | Encrypted string of the files **attribute**. 
+**encryptedFiles** | Text         | No            | Encrypted string of the **files** attribute. 
 **checksum**    | Text          | Yes           | SHA3 Hash of concatenated values : [list of all file checksums] + name + author + license + did
 **categories**  | Array of Text | No            | Optional array of categories associated to the Asset.
 **tags**        | Array of Text | No            | Keywords or tags used to describe this content. Multiple entries in a keyword list are typically delimited by commas. Empty by default.

--- a/8/README.md
+++ b/8/README.md
@@ -55,7 +55,7 @@ The main motivations of this OEP are to:
 
 ## Life Cycle of Metadata
 
-Metadata is first created by the publisher of the asset. The publisher has knowledge of the file URL's, and they are stored in plaintext. After publication, the metadata store (Aquarius) will return the Metadata with encrypted URL's. 
+Metadata is first created by the publisher of the asset. The publisher has knowledge of the file URL's, and they are stored in plaintext in the **files** attribute. After publication, the metadata store (Aquarius) will return the Metadata with this data encrypted. The result will be a single ciphertext of the attribute. The **dateCreated** attribute is created by the metadata store. 
 
 ## Base Attributes
 
@@ -66,7 +66,7 @@ The stored _values_ can be empty. The following are the base attributes:
 Attribute       |   Type        |   Required    | Description
 ----------------|---------------|---------------|----------------------
 **name**        | Text          | Yes           | Descriptive name or title of the Asset.
-**dateCreated** | DateTime      | Yes           | The date on which the asset was created or was added. ISO 8601 format, Coordinated Universal Time, (`2019-01-31T08:38:32Z`).
+**dateCreated** | DateTime      | No            | The date on which the asset was created or was added. ISO 8601 format, Coordinated Universal Time, (`2019-01-31T08:38:32Z`).
 **author**      | Text          | Yes           | Name of the entity generating this data (e.g. Tfl, Disney Corp, etc.).
 **license**     | Text          | Yes           | Short name referencing the license of the asset (e.g. Public Domain, CC-0, CC-BY, No License Specified, etc. ). If it's not specified, the following value will be added: "No License Specified".
 **contentType** | Text          | Yes           | File format, if applicable.


### PR DESCRIPTION
Small change to Metadata to reflect how Aquarius handles DDO. 
 - dateCreated is not strict anymore, but we should follow UTC ISO
 - dateCreated not required, since publishers don't create this attrib
 - new attrib; encryptedFiles
 - files and encryptedFiles not required, since only one is necessary