### PR TITLE
OEP-8: move file-related metadata to files array

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -78,19 +78,15 @@ Attribute       |   Type        |   Required    | Description
 **dateCreated** | DateTime      | Yes   | The date on which the asset was created by the originator. ISO 8601 format, Coordinated Universal Time, (`2019-01-31T08:38:32Z`).
 **author**      | Text          | Yes           | Name of the entity generating this data (e.g. Tfl, Disney Corp, etc.).
 **license**     | Text          | Yes           | Short name referencing the license of the asset (e.g. Public Domain, CC-0, CC-BY, No License Specified, etc. ). If it's not specified, the following value will be added: "No License Specified".
-**contentType** | Text          | Yes           | File format, if applicable.
 **price**       | Number        | Yes           | Price of the asset. If not specified, then the default is 0.
-**files**       | Array of files object | (local)     | Array of File objects including the encrypted file urls, checksum (optional), content length in bytes (optional) and remote resourceId (optional)
+**files**       | Array of files object | (local)     | Array of File objects including the encrypted file urls. Further metadata about each file is stored: contentType, checksum (optional), content length in bytes (optional), encoding (optional), compression (optional) and remote resourceId (optional)
 **encryptedFiles** | Text         | (remote)    | Encrypted string of the **files** attribute. 
 **checksum**    | Text          | Yes           | SHA3 Hash of concatenated values : [list of all file checksums] + name + author + license + did
 **categories**  | Array of Text | No            | Optional array of categories associated to the Asset.
 **tags**        | Array of Text | No            | Keywords or tags used to describe this content. Multiple entries in a keyword list are typically delimited by commas. Empty by default.
 **type**        | Text          | No            | Type of the Asset. Helps to filter by the type of asset. It could be for example ("dataset", "algorithm", "container", "workflow", "other"). It's up to the PROVIDER or MARKETPLACE to use a different list of types or not use it.
 **description** | Text          | No            | Details of what the resource is. For a dataset, this attribute explains what the data represents and what it can be used for.
-**size**        | Text          | No            | Size of the asset (e.g. 18MB). In the absence of a unit (MB, kB etc.), kB will be assumed.
 **copyrightHolder**| Text       | No            | The party holding the legal copyright. Empty by default.
-**encoding**    | Text          | No            | File encoding (e.g. UTF-8).
-**compression** | Text          | No            | File compression (e.g. no, gzip, bzip2, etc).
 **workExample** | Text          | No            | Example of the concept of this asset. This example is part of the metadata, not an external link.
 **links**       | Array of Link | No            | Mapping of links for data samples, or links to find out more information. Links may be to either a URL or another Asset. We expect marketplaces to converge on agreements of typical formats for linked data: The Ocean Protocol itself does not mandate any specific formats as these requirements are likely to be domain-specific.
 **inLanguage**  | Text          | No            | The language of the content. Please use one of the language codes from the [IETF BCP 47 standard](https://tools.ietf.org/html/bcp47).
@@ -105,9 +101,12 @@ This attribute include an array of objects of type `file`. The type file has the
 | Attribute         | Description                                                  |
 | ----------------- | ------------------------------------------------------------ |
 | **url**           | Content Url (mandatory). The URL is encrypted after publication. |
+| **contentType**   | File format, if applicable. |
 | **checksum**      | Checksum of the file using your preferred format (i.e. MD5). Format specified in **checksumType**. If it's not provided can't be validated if the file was not modified after registering. |
 | **checksumType**  | Format of the provided checksum. Can vary according to server (i.e Amazon vs. Azure) |
 | **contentLength** | Size of the file in bytes (optional).                        |
+| **encoding**      | File encoding (e.g. UTF-8). |
+| **compression**   | File compression (e.g. no, gzip, bzip2, etc). |
 | **resourceId**    | Remote identifier of the file in the external provider (optional). It is typically the remote id in the cloud provider. |
 
 Only the **url** attribute is mandatory.

--- a/8/README.md
+++ b/8/README.md
@@ -153,18 +153,25 @@ Here is an example of an Asset metadata object following the above-described sch
     "price": 10,
     "files": [
       {
+        "contentType": "application/zip",
+        "encoding": "UTF-8",
+        "compression": "zip",
         "checksum": "2bf9d229d110d1976cdf85e9f3256c7f",
         "checksumType": "MD5",
         "contentLength": 12057507,
         "url": "https://s3.amazonaws.com/assets/training.zip"
       },
       {
+        "contentType": "text/txt",
+        "encoding": "UTF-8",
+        "compression": "none",
         "checksum": "354d19c0733c47ef3a6cce5b633116b0",
         "checksumType": "MD5",
         "contentLength": 928,
         "url": "https://s3.amazonaws.com/datacommons/monkey_labels.txt"
       },
       {
+        "contentType": "application/zip",
         "url": "https://s3.amazonaws.com/datacommons/validation.zip"
       }
     ],


### PR DESCRIPTION
Putting all those file-related metadata attributes to files array makes the metadata model more flexible so it can be used no matter how many files are added for an asset.

### Current state

When more than 1 file is added to an asset, the following attributes under `base` don't make sense anymore since they depend on the added files and they can be different for each file:

- `contentType`
- `compression`
- `encoding`
- `size`

### Proposal

Move all those attributes under the respective entry in the `files` array. We can kick out `size` since there's already `contentLength` present for each file. Resulting in:

```json
"files": [
    {
        "contentType": "application/zip",
        "encoding": "UTF-8",
        "compression": "zip",
        "checksum": "2bf9d229d110d1976cdf85e9f3256c7f",
        "checksumType": "MD5",
        "contentLength": 12057507,
        "url": "https://s3.amazonaws.com/assets/training.zip"
    },
    {
        "contentType": "text/txt",
        "encoding": "UTF-8",
        "compression": "none",
        "checksum": "354d19c0733c47ef3a6cce5b633116b0",
        "checksumType": "MD5",
        "contentLength": 928,
        "url": "https://s3.amazonaws.com/datacommons/monkey_labels.txt"
    },
    {
        "contentType": "application/zip",
        "url": "https://s3.amazonaws.com/datacommons/validation.zip"
    }
],
```