### PR TITLE
Change purchase endpoint to consume endpoint

### DIFF
--- a/11/README.md
+++ b/11/README.md
@@ -165,8 +165,8 @@ def build_condition_key(contract_address, fingerprint, template_id):
    - An integer defining when the agreement is fulfilled in case there are multiple terminal conditions, according to the Service Agreement smart contract
 
    A service of type "Access" contains 2 different endpoints:
-   - **serviceEndpoint** - A URL to fetch data decryption keys from
-   - **purchaseEndpoint** - A URL to initialize the Service Agreement
+   - **serviceEndpoint** - A URL to initialize the Service Agreement
+   - **consumeEndpoint** - A URL to fetch data decryption keys from
 
     An example of a complete DDO can be found [here](./ddo.example.json). Please do note that the condition's order in the DID document should reflect the same order in on-chain service agreement.
 

--- a/11/ddo.example.json
+++ b/11/ddo.example.json
@@ -98,8 +98,8 @@
 			"templateId": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
 
 			"serviceDefinitionId": "1",
-			"serviceEndpoint": "http://localhost:8030/api/v1/brizo/services/consume?consumerAddress=${consumerAddress}&serviceAgreementId=${serviceAgreementId}&url=${url}",
-			"purchaseEndpoint": "http://localhost:8030/api/v1/brizo/services/access/initialize",
+			"serviceEndpoint": "http://localhost:8030/api/v1/brizo/services/access/initialize",
+			"consumeEndpoint": "http://localhost:8030/api/v1/brizo/services/consume?consumerAddress=${consumerAddress}&serviceAgreementId=${serviceAgreementId}&url=${url}",
 
 			"name": "dataAssetAccessServiceAgreement",
 			"description": "",


### PR DESCRIPTION
To improve the consistency in the naming we are going to update the name from purchaseEndpoint to consumeEndpoint.