### PR TITLE
Small fixes in OEP-8

### DIFF
--- a/8/README.md
+++ b/8/README.md
@@ -116,7 +116,7 @@ Attribute       |   Type        |   Required    | Description
 **description** | Text          | No            | Details of what the resource is. For a dataset, this attribute explains what the data represents and what it can be used for.
 **copyrightHolder**| Text       | No            | The party holding the legal copyright. Empty by default.
 **workExample** | Text          | No            | Example of the concept of this asset. This example is part of the metadata, not an external link.
-**links**       | Array of Link | No            | Mapping of links for data samples, or links to find out more information. Links may be to either a URL or another Asset. We expect marketplaces to converge on agreements of typical formats for linked data: The Ocean Protocol itself does not mandate any specific formats as these requirements are likely to be domain-specific.
+**links**       | Array of Link | No            | Mapping of links for data samples, or links to find out more information. Links may be to either a URL or another Asset. We expect marketplaces to converge on agreements of typical formats for linked data: The Ocean Protocol itself does not mandate any specific formats as these requirements are likely to be domain-specific. The links array can be an empty array, but if there is a link object in it, then an "url" is required in that link object.
 **inLanguage**  | Text          | No            | The language of the content. Please use one of the language codes from the [IETF BCP 47 standard](https://tools.ietf.org/html/bcp47).
 
 #### File Attributes
@@ -264,7 +264,7 @@ Similarly, this is how the metadata file would look as a response to querying Aq
     "tags": [],
     "price": 0,
     "encryptedFiles": "0x7a0d1c66ae861…df43aa9",
-    "checksum": "d7296ccaaec630452be65a13ea1d2d750f071b6f50b779e99cc9adf05faebfca",
+    "checksum": "0xd7296ccaaec630452be65a13ea1d2d750f071b6f50b779e99cc9adf05faebfca",
     "datePublished": "2019-05-16T12:41:01Z"
   },
   "additionalInformation": {


### PR DESCRIPTION
1. Add a "0x" to the start of the example remote `checksum` (overall checksum)
2. The "links" array can be an empty array, but if there is a link object in it, then an "url" is required in that link object. (Plecos already checks this.)