### PR TITLE
Fix broken link from the DID Registry

### DIFF
--- a/7/did-method-spec.md
+++ b/7/did-method-spec.md
@@ -1,0 +1,3 @@
+This file has moved. Please see [OEP-7](https://github.com/oceanprotocol/OEPs/tree/master/7).
+
+Do not delete this file! It is where [the DID Method Registry](https://w3c-ccg.github.io/did-method-registry/) links.


### PR DESCRIPTION
The link for Ocean Protocol in the [DID Registry](https://w3c-ccg.github.io/did-method-registry/#the-registry) is currently broken, i.e.

https://github.com/oceanprotocol/OEPs/blob/master/7/did-method-spec.md

is broken. This pull request fixes it.

Note that the `did-method-spec.md` file uses an absolute rather than a relative URL for OEP-7.