### PR TITLE
Use only serviceEndpoint in the access service

### DIFF
--- a/11/v0.2/ddo.example.json
+++ b/11/v0.2/ddo.example.json
@@ -111,8 +111,7 @@
             "type": "access",
             "index": 1,
             "templateId": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
-            "serviceEndpoint": "http://localhost:8030/api/v1/brizo/services/access/initialize",
-            "consumeEndpoint": "http://localhost:8030/api/v1/brizo/services/consume?consumerAddress=${consumerAddress}&serviceAgreementId=${serviceAgreementId}&url=${url}",
+            "serviceEndpoint": "http://localhost:8030/api/v1/brizo/services/consume?consumerAddress=${consumerAddress}&serviceAgreementId=${serviceAgreementId}&url=${url}",
             "main": {
                 "creator": "0x00Bd138aBD70e2F00903268F3Db08f2D25677C9e",
                 "datePublished": "2019-04-09T19:02:11Z",


### PR DESCRIPTION
Remove call to initialize, and use only the service endpoint.