### PR TITLE
Status flags updates

### DIFF
--- a/7/v0.3/README.md
+++ b/7/v0.3/README.md
@@ -103,16 +103,14 @@ A DDO document is composed of standard DDO attributes:
 * `verifiableCredential`
 * `dataToken`
 * `service`
-* `isDisabled`   - optional flag, if set, will disable asset consumption, but the asset will appear in searches. This a temporary flag, publisher can switch it any time.
 * `credentials`   - optional flag, which describes the credentials needed to access a dataset (see below)
 
-
-
-Asset metadata can be included as one of the objects inside the `"service"` array, with type `"metadata"`.
+Asset metadata must be included as one of the objects inside the `"service"` array, with type `"metadata"`.
 
 #### DDO Services
 
 Each type of asset (dataset, algorithm, workflow, etc, ..) typically will have associated different kind of services. There are multiple type of services that are commonly added to all the assets:
+
 * metadata - describing the asset
 * provenance - describing the asset provenance
 * access - describing how the asset can be downloaded

--- a/8/v0.5/README.md
+++ b/8/v0.5/README.md
@@ -84,10 +84,10 @@ A `metadata` object has the following attributes, all of which are objects.
 Attribute                   | Required | Description
 ----------------------------|----------|----------|
 **`main`**                  | Yes      | Main attributes used to calculate the service checksum |
-**`curation`**              | (remote) | Curation attributes
+**`curation`**              | No.      | Curation attributes
 **`additionalInformation`** | No       | Optional attributes
 **`encryptedFiles`**        | (remote) | Encrypted string of the `attributes.main.files` object.
-**`encryptedServices`**      | (remote) | Encrypted string of the `attributes.main.services` object.
+**`encryptedServices`**     | (remote) | Encrypted string of the `attributes.main.services` object.
 
 The `main`, `curation` and `additionalInformation` attributes are independent of the asset type, all assets have those metadata sections.
 
@@ -164,12 +164,11 @@ The publisher of a DDO MAY add additional attributes or change the above object 
 
 A `curation` object has the following attributes.
 
-Attribute       |   Type           |   Required    | Description
-----------------|------------------|---------------|----------------------
-**`rating`**      | Number (decimal) | Yes           | Decimal value between 0 and 1. 0 is the default value.
-**`numVotes`**    | Integer          | Yes           | Number of votes. 0 is the default value.
-**`schema`**      | Text             | No            | Schema applied to calculate the rating.
-**`isListed`**    | Boolean          | No            | Flag unsuitable content. False by default. If it's true, the content must not be returned.
+Attribute             |   Type           |   Required    | Description
+----------------------|------------------|---------------|----------------------
+**`isListed`**        | Boolean          | No            | Use to flag unsuitable content. True by default. If it's false, the content must not be returned.
+**`isRetired`**       | Boolean          | No            | Flag retired content. False by default. If it's true, the content may either not be returned, or returned with a note about retirement.
+**`isOrderDisabled`** | Boolean          | No            | For temporarily disabling ordering assets, e.g. when file host is in maintenance. False by default. If it's true, no ordering of assets for download or compute should be allowed.
 
 ## Example of Local Metadata
 
@@ -200,6 +199,11 @@ Attribute       |   Type           |   Required    | Description
     "tags": [],
     "updateFrequency": null,
     "structuredMarkup": []
+  },
+  "curation": {
+    "isListed": true,
+    "isRetired": false,
+    "isOrderDisabled": false
   }
 }
 ```
@@ -233,12 +237,6 @@ Similarly, this is how the metadata file would look as a response to querying Aq
           "datePublished": "2019-05-16T12:41:01Z"
         },
         "encryptedFiles": "0x7a0d1c66ae861…df43aa9",
-        "curation":{  
-          "rating": 1,
-          "numVotes": 7,
-          "schema": "BINARY",
-          "isListed": true
-        },
         "additionalInformation": {  
           "description": "Weather forecast of Europe/Madrid in XML format",
           "copyrightHolder": "Norwegian Meteorological Institute",
@@ -247,6 +245,11 @@ Similarly, this is how the metadata file would look as a response to querying Aq
           "tags": [],
           "updateFrequency": null,
           "structuredMarkup": []
+        },
+        "curation": {
+          "isListed": true,
+          "isRetired": false,
+          "isOrderDisabled": false
         }
       }
     }


### PR DESCRIPTION
To give all the `is..` things a consistent place I'm proposing to actually use the `curation` attribute within the metadata service for everything which is signaled by the publisher.

Because it is actual curation, the publisher curates the status of their data set on their own, all of which should only happen within the metadata service. All other root DDO things like `isConsumable` or `isInPurgatory` are not set by the publisher but added automatically so it quickly can become confusing to know which attributes are updated by publisher and which ones by Aquarius itself. Sticking to the principle that all metadata the publisher updates is within the metadata service keeps it more transparent and consistent how those values can change.

So we would get this as the default within the meta data service:

```json
  "curation": {
    "isListed": true,
    "isRetired": false,
    "isOrderDisabled": false
  }
```

---

Requires updates in:

- [x] ocean.js (https://github.com/oceanprotocol/ocean.js/pull/789)
- [x] ocean.py
- [ ] plecos?
- [ ] aquarius?

---

Implications for:

- https://github.com/oceanprotocol/ocean.js/pull/697
- https://github.com/oceanprotocol/market/issues/452
- https://github.com/oceanprotocol/market/pull/463
- https://github.com/oceanprotocol/market/issues/445
- https://github.com/oceanprotocol/ocean.py/pull/314
- 
